### PR TITLE
Update to rave ~0.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commonjs"
   ],
   "peerDependencies": {
-    "rave": "~0.1"
+    "rave": "~0.2"
   },
   "license": "MIT",
   "bugs": {

--- a/rave.js
+++ b/rave.js
@@ -18,6 +18,7 @@ function create (context) {
       {
         extensions: extensions,
         hooks: {
+          locate: locate,
           translate: function (file) {
             var pragma = '/** @jsx React.DOM */';
             return jsxTransformer.transform(pragma + file.source).code;
@@ -27,4 +28,10 @@ function create (context) {
     ]
   };
 
+}
+
+function locate (load) {
+	var metadata = load.metadata;
+	metadata.dontAddExt = true;
+	return false;
 }


### PR DESCRIPTION
Rave 0.2.x load extensions require a small change to deal with file extensions applied in the locate hook.  This will likely change again in 0.3.0.  
